### PR TITLE
ci: use repo-token to avoid being rate-limited

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -18,6 +18,8 @@ jobs:
       run: npm install
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install protoc-gen-js
       run: npm install -g protoc-gen-js
     - name: Generate gRPC-web files


### PR DESCRIPTION
See [Arduino/setup-protoc README.md](https://github.com/arduino/setup-protoc/blob/3ea1d70ac22caff0b66ed6cb37d5b7aadebd4623/README.md#usage)