### PR TITLE
refactor: consolidate proto generation

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -1,6 +1,7 @@
 PROTO_OUT_DIR=src/proto/
 GRPC_WEB_PLUGIN := tools/protoc-gen-grpc-web
 GRPC_WEB_OUTPUT_OPTIONS := import_style=typescript,mode=grpcwebtext
+SERVICES := user todolist
 
 all: frontend
 
@@ -8,7 +9,7 @@ all: frontend
 frontend: proto
 	npm run build
 
-proto: src/proto/UserServiceClientPb.ts src/proto/TodolistServiceClientPb.ts
+proto: $(SERVICES:%=src/proto/%ServiceClientPb.ts) $(SERVICES:%=src/proto/%_pb.d.ts)
 
 tools/:
 	@mkdir -p tools
@@ -18,10 +19,7 @@ $(PROTO_OUT_DIR):
 
 PROTOC_FLAGS := -I../proto --plugin=protoc-gen-grpc-web=$(GRPC_WEB_PLUGIN)
 
-src/proto/user_pb.d.ts src/proto/UserServiceClientPb.ts: ../proto/user.proto tools/protoc-gen-grpc-web $(PROTO_OUT_DIR)
-	protoc $(PROTOC_FLAGS) --js_out=import_style=commonjs:src/proto --grpc-web_out=$(GRPC_WEB_OUTPUT_OPTIONS):src/proto $<
-
-src/proto/todolist_pb.d.ts src/proto/TodolistServiceClientPb.ts: ../proto/todolist.proto tools/protoc-gen-grpc-web $(PROTO_OUT_DIR)
+src/proto/%_pb.d.ts src/proto/%ServiceClientPb.ts: ../proto/%.proto tools/protoc-gen-grpc-web $(PROTO_OUT_DIR)
 	protoc $(PROTOC_FLAGS) --js_out=import_style=commonjs:src/proto --grpc-web_out=$(GRPC_WEB_OUTPUT_OPTIONS):src/proto $<
 
 


### PR DESCRIPTION
## Summary
- centralize UI proto service generation with a list of services
- collapse duplicated proto build rules into a single pattern rule

## Testing
- `make proto` *(fails: protoc-gen-js: program not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890756c3f0c832caf46e69f03096a2b