### PR TITLE
server: allow overriding config by environment variables

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use sqlx::{
 #[derive(Serialize, Deserialize)]
 pub struct Config {
     pub login: Login,
-    pub database: Option<Database>,
+    pub database: Database,
 }
 
 impl Config {
@@ -19,29 +19,90 @@ impl Config {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct ConfigFile {
+    pub login: Option<Login>,
+    pub database: Option<Database>,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct Login {
     #[serde(serialize_with = "serialize_secret")]
     pub client_id: SecretString,
 }
 
 pub fn load() -> Result<Config, LoadError> {
-    toml::from_str(&std::fs::read_to_string("server.toml").map_err(LoadError::IO)?)
-        .map_err(LoadError::Parse)
+    let config_file: ConfigFile =
+        toml::from_str(&std::fs::read_to_string("server.toml").map_err(LoadError::IO)?)
+            .map_err(LoadError::Parse)?;
+    let login: Login = std::env::var("GOOGLE_LOGIN_CLIENT_ID")
+        .ok()
+        .map(|client_id| Login {
+            client_id: SecretString::from(client_id),
+        })
+        .or(config_file.login)
+        .ok_or(LoadError::MissingEssentialValue("login.client_id"))?;
+    let database = Database::from_env()
+        .or(config_file.database)
+        .or(Some(Default::default()));
+    Ok(Config { login, database })
 }
 
 #[derive(Debug)]
 pub enum LoadError {
     IO(std::io::Error),
     Parse(toml::de::Error),
+    MissingEssentialValue(&'static str),
 }
 
-#[derive(Serialize, Deserialize, Default, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Database {
-    host: Option<String>,
-    user: Option<String>,
+    pub host: Option<String>,
+    pub user: Option<String>,
     #[serde(serialize_with = "serialize_optional_secret")]
-    password: Option<SecretString>,
-    database: Option<String>,
+    pub password: Option<SecretString>,
+    pub database: Option<String>,
+}
+
+impl Default for Database {
+    fn default() -> Self {
+        Self {
+            host: Some(String::from("localhost")),
+            user: Some(String::from("postgres")),
+            password: None,
+            database: Some(String::from("accountcat")),
+        }
+    }
+}
+
+impl Database {
+    pub fn from_env() -> Self {
+        Self {
+            host: std::env::var("DATABASE_HOST").ok(),
+            user: std::env::var("DATABASE_USER").ok(),
+            password: std::env::var("DATABASE_PASSWORD")
+                .map(SecretString::from)
+                .ok(),
+            database: std::env::var("DATABASE_NAME").ok(),
+        }
+    }
+
+    pub fn or(self, other: Option<Self>) -> Self {
+        let Some(other) = other else {
+            return self;
+        };
+        let Database {
+            host,
+            user,
+            password,
+            database,
+        } = self;
+        Self {
+            host: host.or(other.host),
+            user: user.or(other.user),
+            password: password.or(other.password),
+            database: database.or(other.database),
+        }
+    }
 }
 
 impl From<Database> for PgConnectOptions {
@@ -51,11 +112,11 @@ impl From<Database> for PgConnectOptions {
             user,
             password,
             database,
-        } = value;
+        } = value.or(Some(Default::default()));
         let mut options = PgConnectOptions::new()
-            .host(&host.unwrap_or_else(|| String::from("localhost")))
-            .username(&user.unwrap_or_else(|| String::from("postgres")))
-            .database(&database.unwrap_or_else(|| String::from("accountcat")));
+            .host(&host.unwrap())
+            .username(&user.unwrap())
+            .database(&database.unwrap());
         if let Some(password) = password {
             options = options.password(password.expose_secret());
         }

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -4,6 +4,6 @@ use crate::config;
 
 pub async fn run() {
     let config = config::load().unwrap();
-    let pool: PgPool = config.database.unwrap_or_default().into();
+    let pool: PgPool = config.database.into();
     sqlx::migrate!("./migrations").run(&pool).await.unwrap();
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -37,7 +37,7 @@ async fn init_state() -> ServerState {
         .expect("init jwt verifier");
     ServerState {
         jwt_verify: verifier,
-        database: database.unwrap_or_default().into(),
+        database: database.into(),
     }
 }
 


### PR DESCRIPTION
1. allow overriding config by environment variables
2. make config file `server.toml` optional, as long as essential config values are resolved