### PR TITLE
server: add -a flag to run db migration at start

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
-use accountcat::{config, server};
+use accountcat::{
+    config,
+    server::{self, ServerArg},
+};
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
@@ -7,22 +10,27 @@ struct Args {
     subcommand: Option<Command>,
 }
 
-#[derive(Subcommand, Default)]
+#[derive(Subcommand)]
 enum Command {
     /// run accountcat server
-    #[default]
-    Server,
+    Server(ServerArg),
     /// run database migration
     Migrate,
     /// Dump current server settings
     Settings,
 }
 
+impl Default for Command {
+    fn default() -> Self {
+        Command::Server(Default::default())
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
     match args.subcommand.unwrap_or_default() {
-        Command::Server => server::main().await,
+        Command::Server(arg) => server::main(&arg).await,
         Command::Migrate => accountcat::migration::run().await,
         Command::Settings => config::print_settings(),
     }


### PR DESCRIPTION
this might be useful to save a migrator service or an init step