### PR TITLE
fix(ui): preserve leading zero in decimal input

### DIFF
--- a/ui/src/formatInputNumber.test.ts
+++ b/ui/src/formatInputNumber.test.ts
@@ -17,9 +17,15 @@ describe("formatInputNumber", () => {
 	});
 	test("should allow on-going decimal input", () => {
 		expect(formatInputNumber("10.")).toBe("10.");
+		expect(formatInputNumber("0.")).toBe("0.");
 	});
 	test("should remove charaters other that digits and deciaml seperator", () => {
 		expect(formatInputNumber("10,0")).toBe("100");
 		expect(formatInputNumber("12b3ac")).toBe("123");
+	});
+	test("should keep leading zero for decimals less than one", () => {
+		expect(formatInputNumber("0.5")).toBe("0.5");
+		expect(formatInputNumber("00.5")).toBe("0.5");
+		expect(formatInputNumber(".5")).toBe("0.5");
 	});
 });

--- a/ui/src/formatInputNumber.ts
+++ b/ui/src/formatInputNumber.ts
@@ -1,7 +1,12 @@
 export default function formatInputNumber(input: string): string {
-	const matches = input.replace(/[^\d.]/g, "").match(/\d+.?(\d+)?/);
-	if (!matches) {
+	const sanitized = input.replace(/[^\d.]/g, "");
+	const matches = sanitized.match(/\d*(?:\.\d*)?/);
+	if (!matches || matches[0] === "") {
 		return "0";
 	}
-	return matches[0].replace(/^0+(?=[^0]+)/, "");
+	const result = matches[0];
+	if (result.startsWith(".")) {
+		return `0${result}`;
+	}
+	return result.replace(/^0+(?=\d)/, "");
 }


### PR DESCRIPTION
## Summary
- preserve leading zero for decimals in `formatInputNumber`
- extend tests for decimal input and sanitize behavior

## Testing
- `npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off src/formatInputNumber.ts src/formatInputNumber.test.ts`
- `npx rstest src/formatInputNumber.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1516f185c832cb82e893d6be860c7