### PR TITLE
deploy!: bind postgresql data volume to correct location

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -7,7 +7,7 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - database-data:/var/lib/postgresql
+      - database-data:/var/lib/postgresql/data
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
 volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ services:
   database:
     image: docker.io/postgres:17.5
     volumes:
-      - database-data:/var/lib/postgresql
+      - database-data:/var/lib/postgresql/data
     healthcheck:
       test:
         - CMD-SHELL


### PR DESCRIPTION
avoid nested bind for postgresql containers before v18

Until v18, postresql image declares an anonymous volume at /var/lib/postgresql/data. So bind mounting /var/lib/postgresql create a nested mounting issue.

this change might break local dev database and require a reset.