### PR TITLE
Isolate a CWD changing test cases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 pub mod accounting_service;
 mod auth;
 pub mod config;
-mod csp;
+pub mod csp;
 pub mod idl;
 pub mod jwtutils;
 pub mod migration;
 pub mod protobufutils;
 mod secret_se;
-mod serve_dist;
+pub mod serve_dist;
 pub mod server;
 pub mod testing;
 mod todolist_service;

--- a/src/serve_dist.rs
+++ b/src/serve_dist.rs
@@ -213,9 +213,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_serve_binary() {
-        let image = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui/src/logo.png");
+        let image = "ui/src/logo.png";
         let test_dir = TempDir::new().unwrap();
-        std::fs::copy(&image, test_dir.path().join("logo.png")).unwrap();
+        std::fs::copy(image, test_dir.path().join("logo.png")).unwrap();
         let serve_dist = ServeDist::new(test_dir.path().into()).unwrap();
         let service = ServiceBuilder::new().layer(NonceLayer).service(serve_dist);
         let router = axum::Router::new().fallback_service(service);
@@ -230,7 +230,7 @@ mod tests {
             .unwrap();
         let response = response.into_body().collect().await.unwrap().to_bytes();
         let expected_bytes = {
-            let mut f = File::open(&image).unwrap();
+            let mut f = File::open(image).unwrap();
             let mut buf = Vec::new();
             f.read_to_end(&mut buf).unwrap();
             buf

--- a/src/serve_dist.rs
+++ b/src/serve_dist.rs
@@ -123,13 +123,9 @@ impl<B> Future for ServeDistFuture<B> {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fs::File,
-        io::{Read, Write},
-        path::PathBuf,
-    };
+    use std::{fs::File, io::Read, path::PathBuf};
 
-    use axum::body::{Body, Bytes};
+    use axum::body::Body;
     use http::Request;
     use http_body_util::BodyExt;
     use temp_dir::TempDir;
@@ -159,56 +155,6 @@ mod tests {
             dist_dir_path.join("index.html"),
             build_path(&dist_dir_path, "/../outside.html")
         );
-    }
-
-    fn create_dummy_file(directory: PathBuf, name: &str) {
-        let mut file = File::create(directory.join(name)).unwrap();
-        file.write_all(format!("content of {name}").as_bytes())
-            .unwrap();
-    }
-
-    struct ChangeCwd {
-        original: PathBuf,
-    }
-
-    impl ChangeCwd {
-        fn new(to: PathBuf) -> Self {
-            let instance = Self {
-                original: std::env::current_dir().unwrap(),
-            };
-            std::env::set_current_dir(to).unwrap();
-            instance
-        }
-    }
-
-    impl Drop for ChangeCwd {
-        fn drop(&mut self) {
-            std::env::set_current_dir(&self.original).unwrap();
-        }
-    }
-
-    #[tokio::test]
-    async fn test_serve_dist_allow_specifying_relative_path() {
-        let test_dir = TempDir::new().unwrap();
-        let assert_dir_path = test_dir.path().join("assets");
-        std::fs::create_dir(&assert_dir_path).unwrap();
-        create_dummy_file(assert_dir_path.clone(), "index.html");
-        create_dummy_file(assert_dir_path, "a.txt");
-        let _change_cwd = ChangeCwd::new(test_dir.path().into());
-        let serve_dist = ServeDist::new(PathBuf::from("assets")).unwrap();
-        let service = ServiceBuilder::new().layer(NonceLayer).service(serve_dist);
-        let router = axum::Router::new().fallback_service(service);
-        let response = router
-            .oneshot(
-                Request::builder()
-                    .uri("/a.txt")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        let response = response.into_body().collect().await.unwrap().to_bytes();
-        assert_eq!(Bytes::from_static(b"content of a.txt"), response);
     }
 
     #[tokio::test]

--- a/src/testing/cwd.rs
+++ b/src/testing/cwd.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+
+pub struct ChangeCwd {
+    original: PathBuf,
+}
+
+impl ChangeCwd {
+    pub fn new(to: PathBuf) -> Self {
+        let instance = Self {
+            original: std::env::current_dir().unwrap(),
+        };
+        std::env::set_current_dir(to).unwrap();
+        instance
+    }
+}
+
+impl Drop for ChangeCwd {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.original).unwrap();
+    }
+}

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -3,6 +3,7 @@ use tonic::{Request, async_trait};
 
 use crate::{auth::IdClaimExtractor, jwtutils::Claims};
 
+pub mod cwd;
 pub mod test_database;
 
 pub struct DummyIdClaimExtractor {

--- a/tests/serve_dist.rs
+++ b/tests/serve_dist.rs
@@ -1,0 +1,40 @@
+use std::{fs::File, io::Write, path::PathBuf};
+
+use accountcat::{csp::NonceLayer, serve_dist::ServeDist, testing::cwd::ChangeCwd};
+use axum::body::Body;
+use http::Request;
+use http_body_util::BodyExt;
+use temp_dir::TempDir;
+use tower::{ServiceBuilder, ServiceExt};
+
+fn create_dummy_file(directory: PathBuf, name: &str) {
+    let mut file = File::create(directory.join(name)).unwrap();
+    file.write_all(format!("content of {name}").as_bytes())
+        .unwrap();
+}
+#[tokio::test]
+async fn test_serve_dist_allow_specifying_relative_path() {
+    let test_dir = TempDir::new().unwrap();
+    let assert_dir_path = test_dir.path().join("assets");
+    std::fs::create_dir(&assert_dir_path).unwrap();
+    create_dummy_file(assert_dir_path.clone(), "index.html");
+    create_dummy_file(assert_dir_path, "a.txt");
+    let _change_cwd = ChangeCwd::new(test_dir.path().into());
+    let serve_dist = ServeDist::new(PathBuf::from("assets")).unwrap();
+    let service = ServiceBuilder::new().layer(NonceLayer).service(serve_dist);
+    let router = axum::Router::new().fallback_service(service);
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/a.txt")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let response = response.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(
+        axum::body::Bytes::from_static(b"content of a.txt"),
+        response
+    );
+}


### PR DESCRIPTION
refactor a ServeDist test case that changes CWD during testing into a standalone test program to prevent it from polluting CWD of other test cases.

Fix #73