### PR TITLE
ci: avoid docker hub ratelimit

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,10 +14,10 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: docker.io/rust:1-bookworm
+      image: public.ecr.aws/docker/library/rust:1-bookworm
     services:
       database:
-        image: docker.io/postgres:17.5
+        image: public.ecr.aws/docker/library/postgres:17.5
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_DB: accountcat


### PR DESCRIPTION
Github action runner pulling images from docker hub might hit the ratelimit and requires authentication. Using public AWS ECR to avoid hitting ratelimit.

GitHub action runner seems to not supporting using mirror.gcr.io as registry mirror, so we use AWS ECR public gallery for images pulled by runners.