### PR TITLE
Add PKI generation CLI command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "accountcat"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
  "base64",
  "clap",
@@ -17,9 +18,12 @@ dependencies = [
  "jsonwebtoken",
  "mime_guess",
  "num-traits",
+ "openssl",
  "pin-project-lite",
  "prost",
  "prost-types",
+ "rand",
+ "rcgen",
  "reqwest",
  "secrecy",
  "serde",
@@ -799,6 +803,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1789,6 +1808,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "openssl"
+version = "0.10.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.110"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2296,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -4049,6 +4119,15 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/README.md
+++ b/README.md
@@ -5,5 +5,15 @@ Personal finace helper.
 The project is still early stage. The development priority will focus on issues found when dogfooding to make it a useful daily driver for the author.
 
 ## Demo
-Demo hosted on render.com free-tier: https://accountcat-demo.onrender.com/  
+Demo hosted on render.com free-tier: https://accountcat-demo.onrender.com/
 ⚠️Database will be purged every 30 days. You can take a look and try it out, but don't rely on it keeping your data.
+
+## Generating mutual TLS certificates
+
+The server binary now includes a helper for issuing self-signed PKI assets suitable for local mTLS testing. Run:
+
+```
+cargo run --bin accountcat -- pki --out-dir ./pki --server-san localhost --server-san 127.0.0.1
+```
+
+The command writes CA, server, and client certificates (alongside PKCS#12 bundles) into the target directory. Use `--pkcs12-password <value>` when you need password-protected archives, and pass additional `--client-san` or `--server-san` values to cover every hostname or IP your gRPC clients connect through.

--- a/accountcat-server/Cargo.toml
+++ b/accountcat-server/Cargo.toml
@@ -16,6 +16,10 @@ pin-project-lite = "0.2.16"
 prost = "0.13.5"
 prost-types = "0.13.5"
 reqwest = { version = "0.12.22", default-features = false, features = ["charset", "http2", "json", "rustls-tls-webpki-roots"] }
+anyhow = "1.0.95"
+openssl = "0.10.68"
+rand = "0.8.5"
+rcgen = "0.13.1"
 secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive"] }
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "postgres", "time", "bigdecimal"] }

--- a/accountcat-server/src/lib.rs
+++ b/accountcat-server/src/lib.rs
@@ -4,6 +4,7 @@ pub mod csp;
 pub mod idl;
 pub mod jwtutils;
 pub mod migration;
+pub mod pki;
 pub mod protobufutils;
 mod secret_se;
 pub mod serve_dist;

--- a/accountcat-server/src/main.rs
+++ b/accountcat-server/src/main.rs
@@ -1,5 +1,6 @@
 use accountcat::{
     config,
+    pki::{self, PkiArgs},
     server::{self, ServerArg},
 };
 use clap::{Parser, Subcommand};
@@ -18,6 +19,8 @@ enum Command {
     Migrate,
     /// Dump current server settings
     Settings,
+    /// Generate PKI artifacts for mutual TLS setups
+    Pki(PkiArgs),
 }
 
 impl Default for Command {
@@ -33,5 +36,11 @@ async fn main() {
         Command::Server(arg) => server::main(&arg).await,
         Command::Migrate => accountcat::migration::run().await,
         Command::Settings => config::print_settings(),
+        Command::Pki(args) => {
+            if let Err(error) = pki::generate(&args) {
+                eprintln!("error: {error:?}");
+                std::process::exit(1);
+            }
+        }
     }
 }

--- a/accountcat-server/src/pki.rs
+++ b/accountcat-server/src/pki.rs
@@ -1,0 +1,219 @@
+use std::{
+    fs,
+    net::IpAddr,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use openssl::{pkcs12::Pkcs12, pkey::PKey, x509::X509};
+use rcgen::{
+    BasicConstraints, Certificate, CertificateParams, DistinguishedName, DnType, DnsName,
+    ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose, PKCS_RSA_SHA256, SanType,
+};
+
+/// Arguments for generating PKI assets used by mutual TLS.
+#[derive(Args, Debug, Clone)]
+pub struct PkiArgs {
+    /// Directory where generated artifacts are written.
+    #[arg(long = "out-dir", default_value = "pki")]
+    pub out_dir: PathBuf,
+
+    /// Common name for the generated certificate authority (CA).
+    #[arg(long = "ca-common-name", default_value = "Accountcat Local CA")]
+    pub ca_common_name: String,
+
+    /// Common name for the server certificate.
+    #[arg(long = "server-common-name", default_value = "accountcat-server")]
+    pub server_common_name: String,
+
+    /// Subject alternative names (SANs) applied to the server certificate.
+    #[arg(
+        long = "server-san",
+        value_name = "SAN",
+        num_args = 1..,
+        default_values_t = [String::from("localhost")]
+    )]
+    pub server_sans: Vec<String>,
+
+    /// Common name for the client certificate.
+    #[arg(long = "client-common-name", default_value = "accountcat-client")]
+    pub client_common_name: String,
+
+    /// Subject alternative names (SANs) applied to the client certificate.
+    #[arg(long = "client-san", value_name = "SAN")]
+    pub client_sans: Vec<String>,
+
+    /// Optional password applied to the generated PKCS#12 bundles.
+    #[arg(long = "pkcs12-password")]
+    pub pkcs12_password: Option<String>,
+}
+
+impl Default for PkiArgs {
+    fn default() -> Self {
+        Self {
+            out_dir: PathBuf::from("pki"),
+            ca_common_name: "Accountcat Local CA".to_string(),
+            server_common_name: "accountcat-server".to_string(),
+            server_sans: vec!["localhost".to_string()],
+            client_common_name: "accountcat-client".to_string(),
+            client_sans: Vec::new(),
+            pkcs12_password: None,
+        }
+    }
+}
+
+/// Generate certificate artifacts for mutual TLS.
+pub fn generate(args: &PkiArgs) -> Result<()> {
+    let out_dir = absolutize(&args.out_dir)?;
+    fs::create_dir_all(&out_dir)
+        .with_context(|| format!("failed to create output directory '{}'", out_dir.display()))?;
+
+    let ca = build_ca(&args.ca_common_name)?;
+    let ca_der = ca.serialize_der()?;
+    let ca_pem = ca.serialize_pem()?;
+    let ca_key_pem = ca.serialize_private_key_pem();
+
+    write_file(&out_dir, "ca.pem", ca_pem.as_bytes())?;
+    write_file(&out_dir, "ca-key.pem", ca_key_pem.as_bytes())?;
+
+    let server = build_server(&args.server_common_name, &args.server_sans)?;
+    let server_der = server.serialize_der_with_signer(&ca)?;
+    let server_pem = server.serialize_pem_with_signer(&ca)?;
+    let server_key_pem = server.serialize_private_key_pem();
+    let server_pkcs12 = build_pkcs12(
+        &server,
+        &server_der,
+        &ca_der,
+        args.pkcs12_password.as_deref(),
+        &args.server_common_name,
+    )?;
+
+    write_file(&out_dir, "server.pem", server_pem.as_bytes())?;
+    write_file(&out_dir, "server-key.pem", server_key_pem.as_bytes())?;
+    write_file(&out_dir, "server.p12", &server_pkcs12)?;
+
+    let client = build_client(&args.client_common_name, &args.client_sans)?;
+    let client_der = client.serialize_der_with_signer(&ca)?;
+    let client_pem = client.serialize_pem_with_signer(&ca)?;
+    let client_key_pem = client.serialize_private_key_pem();
+    let client_pkcs12 = build_pkcs12(
+        &client,
+        &client_der,
+        &ca_der,
+        args.pkcs12_password.as_deref(),
+        &args.client_common_name,
+    )?;
+
+    write_file(&out_dir, "client.pem", client_pem.as_bytes())?;
+    write_file(&out_dir, "client-key.pem", client_key_pem.as_bytes())?;
+    write_file(&out_dir, "client.p12", &client_pkcs12)?;
+
+    println!("Generated mTLS artifacts in {}", out_dir.display());
+
+    Ok(())
+}
+
+fn build_ca(common_name: &str) -> Result<Certificate> {
+    let mut params = CertificateParams::default();
+    params.alg = &PKCS_RSA_SHA256;
+    params.distinguished_name = distinguished_name(common_name);
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params.key_usages = vec![
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+        KeyUsagePurpose::DigitalSignature,
+    ];
+    params.serial_number = Some(rand::random());
+    Certificate::from_params(params).context("failed to build CA certificate")
+}
+
+fn build_server(common_name: &str, sans: &[String]) -> Result<Certificate> {
+    build_leaf_certificate(common_name, sans, ExtendedKeyUsagePurpose::ServerAuth)
+}
+
+fn build_client(common_name: &str, sans: &[String]) -> Result<Certificate> {
+    build_leaf_certificate(common_name, sans, ExtendedKeyUsagePurpose::ClientAuth)
+}
+
+fn build_leaf_certificate(
+    common_name: &str,
+    sans: &[String],
+    eku: ExtendedKeyUsagePurpose,
+) -> Result<Certificate> {
+    let mut params = CertificateParams::default();
+    params.alg = &PKCS_RSA_SHA256;
+    params.distinguished_name = distinguished_name(common_name);
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyEncipherment,
+    ];
+    params.extended_key_usages = vec![eku];
+    params.serial_number = Some(rand::random());
+    params.subject_alt_names = parse_sans(sans)?;
+    if eku == ExtendedKeyUsagePurpose::ServerAuth && params.subject_alt_names.is_empty() {
+        bail!("server certificates require at least one subject alternative name");
+    }
+    Certificate::from_params(params)
+        .with_context(|| format!("failed to build certificate for common name '{common_name}'"))
+}
+
+fn parse_sans(values: &[String]) -> Result<Vec<SanType>> {
+    values
+        .iter()
+        .map(|value| {
+            if let Ok(ip) = value.parse::<IpAddr>() {
+                Ok(SanType::IpAddress(ip))
+            } else {
+                let dns = DnsName::try_from(value.clone())
+                    .with_context(|| format!("invalid DNS name in SAN: {value}"))?;
+                Ok(SanType::DnsName(dns))
+            }
+        })
+        .collect()
+}
+
+fn build_pkcs12(
+    certificate: &Certificate,
+    certificate_der: &[u8],
+    ca_der: &[u8],
+    password: Option<&str>,
+    friendly_name: &str,
+) -> Result<Vec<u8>> {
+    let key_der = certificate.serialize_private_key_der();
+    let pkey = PKey::private_key_from_der(&key_der)
+        .context("failed to parse private key for PKCS#12 export")?;
+    let x509 = X509::from_der(certificate_der)
+        .context("failed to parse signed certificate for PKCS#12 export")?;
+    let ca_x509 =
+        X509::from_der(ca_der).context("failed to parse CA certificate for PKCS#12 export")?;
+    let mut builder = Pkcs12::builder();
+    builder.ca(vec![ca_x509]);
+    let pkcs12 = builder
+        .build(password.unwrap_or(""), friendly_name, &pkey, &x509)
+        .context("failed to construct PKCS#12 archive")?;
+    pkcs12
+        .to_der()
+        .context("failed to encode PKCS#12 archive to DER format")
+}
+
+fn write_file(out_dir: &Path, name: &str, contents: &[u8]) -> Result<()> {
+    let path = out_dir.join(name);
+    fs::write(&path, contents)
+        .with_context(|| format!("failed to write artifact '{}'", path.display()))
+}
+
+fn distinguished_name(common_name: &str) -> DistinguishedName {
+    let mut dn = DistinguishedName::new();
+    dn.push(DnType::CommonName, common_name);
+    dn
+}
+
+fn absolutize(path: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        let cwd = std::env::current_dir().context("failed to determine current directory")?;
+        Ok(cwd.join(path))
+    }
+}

--- a/accountcat-server/tests/pki.rs
+++ b/accountcat-server/tests/pki.rs
@@ -1,0 +1,68 @@
+use std::fs;
+
+use accountcat::pki::{self, PkiArgs};
+use anyhow::Result;
+use openssl::{nid::Nid, pkcs12::Pkcs12};
+use temp_dir::TempDir;
+
+fn read_common_name(cert: &openssl::x509::X509Ref) -> String {
+    cert.subject_name()
+        .entries_by_nid(Nid::COMMONNAME)
+        .next()
+        .and_then(|entry| entry.data().as_utf8().ok())
+        .map(|data| data.to_string())
+        .expect("certificate missing common name")
+}
+
+#[test]
+fn generates_pkcs12_bundles_with_expected_metadata() -> Result<()> {
+    let temp = TempDir::new()?;
+    let output = temp.path().join("artifacts");
+    let args = PkiArgs {
+        out_dir: output.clone(),
+        ca_common_name: "Accountcat Test CA".to_string(),
+        server_common_name: "Accountcat Test Server".to_string(),
+        server_sans: vec!["example.local".to_string()],
+        client_common_name: "Accountcat Test Client".to_string(),
+        client_sans: vec!["client.example.local".to_string()],
+        pkcs12_password: Some("secret".to_string()),
+    };
+
+    pki::generate(&args)?;
+
+    // Server PKCS#12 bundle contains expected CN, SAN, and CA chain.
+    let server_der = fs::read(output.join("server.p12"))?;
+    let server = Pkcs12::from_der(&server_der)?.parse("secret")?;
+    assert_eq!("Accountcat Test Server", read_common_name(&server.cert));
+    let server_sans = server
+        .cert
+        .subject_alt_names()
+        .expect("server certificate missing SAN");
+    let dns_names: Vec<_> = server_sans
+        .iter()
+        .filter_map(|name| name.dnsname())
+        .collect();
+    assert!(dns_names.contains(&"example.local"));
+    let ca_chain = server.chain.expect("server certificate missing CA chain");
+    assert_eq!("Accountcat Test CA", read_common_name(&ca_chain[0]));
+
+    // Client PKCS#12 bundle contains expected CN and SAN.
+    let client_der = fs::read(output.join("client.p12"))?;
+    let client = Pkcs12::from_der(&client_der)?.parse("secret")?;
+    assert_eq!("Accountcat Test Client", read_common_name(&client.cert));
+    let client_sans = client
+        .cert
+        .subject_alt_names()
+        .expect("client certificate missing SAN");
+    let client_dns: Vec<_> = client_sans
+        .iter()
+        .filter_map(|name| name.dnsname())
+        .collect();
+    assert!(client_dns.contains(&"client.example.local"));
+
+    // CA artifacts exist for trust store distribution.
+    assert!(output.join("ca.pem").exists());
+    assert!(output.join("ca-key.pem").exists());
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a `pki` CLI subcommand that emits CA, server, and client certificates for mutual TLS
- implement PKCS#12 export logic with rcgen and OpenSSL helpers and expose it from the library
- add integration coverage for the generated bundles and document the new workflow in the README

## Testing
- cargo test -p accountcat *(fails: protoc missing in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fc3ca95958832caa30b9def5d3cb1d