### PR TITLE
🧪 Add tests for serialize_optional_secret

### DIFF
--- a/accountcat-server/src/secret_se.rs
+++ b/accountcat-server/src/secret_se.rs
@@ -50,5 +50,9 @@ mod tests {
         assert!(serialized.contains("secret = \"<hidden>\""));
         assert!(serialized.contains("optional_secret_some = \"<hidden>\""));
         assert!(serialized.contains("optional_secret_none = \"None\""));
+
+        // Ensure the actual secrets are not present in the serialized output
+        assert!(!serialized.contains("password123"));
+        assert!(!serialized.contains("secret456"));
     }
 }

--- a/accountcat-server/src/secret_se.rs
+++ b/accountcat-server/src/secret_se.rs
@@ -20,3 +20,35 @@ where
         None => "None",
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::SecretString;
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct TestStruct {
+        #[serde(serialize_with = "serialize_secret")]
+        secret: SecretString,
+        #[serde(serialize_with = "serialize_optional_secret")]
+        optional_secret_some: Option<SecretString>,
+        #[serde(serialize_with = "serialize_optional_secret")]
+        optional_secret_none: Option<SecretString>,
+    }
+
+    #[test]
+    fn test_serialization() {
+        let test_struct = TestStruct {
+            secret: SecretString::from(String::from("password123")),
+            optional_secret_some: Some(SecretString::from(String::from("secret456"))),
+            optional_secret_none: None,
+        };
+
+        let serialized = toml::to_string(&test_struct).unwrap();
+
+        assert!(serialized.contains("secret = \"<hidden>\""));
+        assert!(serialized.contains("optional_secret_some = \"<hidden>\""));
+        assert!(serialized.contains("optional_secret_none = \"None\""));
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for `serialize_optional_secret` and `serialize_secret` in `accountcat-server/src/secret_se.rs`.
📊 **Coverage:** Added a test suite covering:
- `serialize_secret`: redacts `SecretString` to `"<hidden>"`.
- `serialize_optional_secret`: redacts `Some(SecretString)` to `"<hidden>"` and `None` to `"None"`.
✨ **Result:** Increased reliability of secret redaction logic during serialization. Verified via code review and manual inspection as environmental constraints prevented local test execution.

---
*PR created automatically by Jules for task [5467402647789234190](https://jules.google.com/task/5467402647789234190) started by @tony84727*