### PR TITLE
🧪 Add tests for RxJS helper createNotifier

### DIFF
--- a/ui/src/rxjsutils.test.ts
+++ b/ui/src/rxjsutils.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, test } from "@rstest/core";
-import { createNotifier, createCallback, createMultiArgumentCallback } from "./rxjsutils";
 import type { Dispatch, SetStateAction } from "react";
+import {
+	createCallback,
+	createMultiArgumentCallback,
+	createNotifier,
+} from "./rxjsutils";
 
 describe("rxjsutils", () => {
 	describe("createNotifier", () => {
 		test("should set dispatch and emit when called", () => {
 			let dispatchAction: SetStateAction<(() => void) | undefined> | undefined;
-			const mockDispatch: Dispatch<SetStateAction<(() => void) | undefined>> = (action) => {
+			const mockDispatch: Dispatch<SetStateAction<(() => void) | undefined>> = (
+				action,
+			) => {
 				dispatchAction = action;
 			};
 
@@ -20,7 +26,7 @@ describe("rxjsutils", () => {
 			const notifier = setFunction();
 
 			let emitted = false;
-			let emittedValue: any = "unemitted";
+			let emittedValue: unknown = "unemitted";
 			event$.subscribe((val) => {
 				emitted = true;
 				emittedValue = val;
@@ -33,10 +39,14 @@ describe("rxjsutils", () => {
 		});
 	});
 
-    describe("createCallback", () => {
+	describe("createCallback", () => {
 		test("should set dispatch and emit event when called", () => {
-			let dispatchAction: any;
-			const mockDispatch: any = (action: any) => {
+			let dispatchAction:
+				| SetStateAction<((event: string) => void) | undefined>
+				| undefined;
+			const mockDispatch: Dispatch<
+				SetStateAction<((event: string) => void) | undefined>
+			> = (action) => {
 				dispatchAction = action;
 			};
 
@@ -48,7 +58,7 @@ describe("rxjsutils", () => {
 			const callback = setFunction();
 
 			let emitted = false;
-			let emittedValue: any;
+			let emittedValue: unknown;
 			event$.subscribe((val) => {
 				emitted = true;
 				emittedValue = val;
@@ -61,22 +71,29 @@ describe("rxjsutils", () => {
 		});
 	});
 
-    describe("createMultiArgumentCallback", () => {
+	describe("createMultiArgumentCallback", () => {
 		test("should set dispatch and emit array of arguments when called", () => {
-			let dispatchAction: any;
-			const mockDispatch: any = (action: any) => {
+			let dispatchAction:
+				| SetStateAction<((...event: [string, number]) => void) | undefined>
+				| undefined;
+			const mockDispatch: Dispatch<
+				SetStateAction<((...event: [string, number]) => void) | undefined>
+			> = (action) => {
 				dispatchAction = action;
 			};
 
-			const event$ = createMultiArgumentCallback<[string, number]>(mockDispatch);
+			const event$ =
+				createMultiArgumentCallback<[string, number]>(mockDispatch);
 
 			expect(dispatchAction).toBeDefined();
 
-			const setFunction = dispatchAction as () => (...event: [string, number]) => void;
+			const setFunction = dispatchAction as () => (
+				...event: [string, number]
+			) => void;
 			const callback = setFunction();
 
 			let emitted = false;
-			let emittedValue: any;
+			let emittedValue: unknown;
 			event$.subscribe((val) => {
 				emitted = true;
 				emittedValue = val;

--- a/ui/src/rxjsutils.test.ts
+++ b/ui/src/rxjsutils.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "@rstest/core";
+import { createNotifier, createCallback, createMultiArgumentCallback } from "./rxjsutils";
+import type { Dispatch, SetStateAction } from "react";
+
+describe("rxjsutils", () => {
+	describe("createNotifier", () => {
+		test("should set dispatch and emit when called", () => {
+			let dispatchAction: SetStateAction<(() => void) | undefined> | undefined;
+			const mockDispatch: Dispatch<SetStateAction<(() => void) | undefined>> = (action) => {
+				dispatchAction = action;
+			};
+
+			const event$ = createNotifier(mockDispatch);
+
+			expect(typeof event$.next).toBe("function");
+			expect(typeof event$.subscribe).toBe("function");
+			expect(dispatchAction).toBeDefined();
+
+			const setFunction = dispatchAction as () => () => void;
+			const notifier = setFunction();
+
+			let emitted = false;
+			let emittedValue: any = "unemitted";
+			event$.subscribe((val) => {
+				emitted = true;
+				emittedValue = val;
+			});
+
+			notifier();
+
+			expect(emitted).toBe(true);
+			expect(emittedValue).toBe(undefined);
+		});
+	});
+
+    describe("createCallback", () => {
+		test("should set dispatch and emit event when called", () => {
+			let dispatchAction: any;
+			const mockDispatch: any = (action: any) => {
+				dispatchAction = action;
+			};
+
+			const event$ = createCallback<string>(mockDispatch);
+
+			expect(dispatchAction).toBeDefined();
+
+			const setFunction = dispatchAction as () => (event: string) => void;
+			const callback = setFunction();
+
+			let emitted = false;
+			let emittedValue: any;
+			event$.subscribe((val) => {
+				emitted = true;
+				emittedValue = val;
+			});
+
+			callback("test-value");
+
+			expect(emitted).toBe(true);
+			expect(emittedValue).toBe("test-value");
+		});
+	});
+
+    describe("createMultiArgumentCallback", () => {
+		test("should set dispatch and emit array of arguments when called", () => {
+			let dispatchAction: any;
+			const mockDispatch: any = (action: any) => {
+				dispatchAction = action;
+			};
+
+			const event$ = createMultiArgumentCallback<[string, number]>(mockDispatch);
+
+			expect(dispatchAction).toBeDefined();
+
+			const setFunction = dispatchAction as () => (...event: [string, number]) => void;
+			const callback = setFunction();
+
+			let emitted = false;
+			let emittedValue: any;
+			event$.subscribe((val) => {
+				emitted = true;
+				emittedValue = val;
+			});
+
+			callback("test-arg", 42);
+
+			expect(emitted).toBe(true);
+			expect(emittedValue).toEqual(["test-arg", 42]);
+		});
+	});
+});


### PR DESCRIPTION
🎯 **What:** 
Added unit tests for the RxJS helper functions in `ui/src/rxjsutils.ts` (`createNotifier`, `createCallback`, `createMultiArgumentCallback`), which previously had no tests.

📊 **Coverage:**
The tests mock the React `Dispatch` function, trigger the state-setter callback correctly to invoke the internal functions, and assert that the RxJS `Subject` instances emit the expected values. All edge cases (no args, single arg, multiple args) are covered.

✨ **Result:**
The test suite now properly catches regressions in the RxJS utility helpers. Test coverage for these hooks is significantly improved.

---
*PR created automatically by Jules for task [4969936303213659282](https://jules.google.com/task/4969936303213659282) started by @tony84727*