### PR TITLE
🧪 test: Add tests for from_proto_timestamp

### DIFF
--- a/accountcat-server/src/protobufutils.rs
+++ b/accountcat-server/src/protobufutils.rs
@@ -13,3 +13,36 @@ pub fn from_proto_timestamp(
 ) -> Result<OffsetDateTime, time::error::ComponentRange> {
     OffsetDateTime::from_unix_timestamp(timestamp.seconds)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_proto_timestamp() {
+        let datetime = OffsetDateTime::from_unix_timestamp(1600000000).unwrap();
+        let timestamp = to_proto_timestamp(datetime);
+        assert_eq!(timestamp.seconds, 1600000000);
+        assert_eq!(timestamp.nanos, 0);
+    }
+
+    #[test]
+    fn test_from_proto_timestamp() {
+        let timestamp = Timestamp {
+            seconds: 1600000000,
+            nanos: 0,
+        };
+        let datetime = from_proto_timestamp(timestamp).unwrap();
+        assert_eq!(datetime.unix_timestamp(), 1600000000);
+    }
+
+    #[test]
+    fn test_from_proto_timestamp_out_of_bounds() {
+        let timestamp = Timestamp {
+            seconds: i64::MAX,
+            nanos: 0,
+        };
+        let result = from_proto_timestamp(timestamp);
+        assert!(result.is_err());
+    }
+}

--- a/accountcat-server/src/protobufutils.rs
+++ b/accountcat-server/src/protobufutils.rs
@@ -27,6 +27,24 @@ mod tests {
     }
 
     #[test]
+    fn test_to_proto_timestamp_with_nanos() {
+        let datetime = OffsetDateTime::from_unix_timestamp_nanos(1600000000123456789).unwrap();
+        let timestamp = to_proto_timestamp(datetime);
+        assert_eq!(timestamp.seconds, 1600000000);
+        assert_eq!(timestamp.nanos, 123456789);
+    }
+
+    #[test]
+    fn test_from_proto_timestamp_negative() {
+        let timestamp = Timestamp {
+            seconds: -1600000000,
+            nanos: 0,
+        };
+        let datetime = from_proto_timestamp(timestamp).unwrap();
+        assert_eq!(datetime.unix_timestamp(), -1600000000);
+    }
+
+    #[test]
     fn test_from_proto_timestamp() {
         let timestamp = Timestamp {
             seconds: 1600000000,


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
- Missing unit tests for the `from_proto_timestamp` and `to_proto_timestamp` conversion functions in `protobufutils.rs`.

📊 **Coverage:** What scenarios are now tested
- Added test for standard unix timestamps covering happy paths.
- Added out-of-bounds component bounds test for `from_proto_timestamp`.
- Added test for `to_proto_timestamp` covering accurate time conversion to protobuf Timestamp.

✨ **Result:** The improvement in test coverage
- Prevents regressions in timezone handling and proto timestamp mappings in the server component.

---
*PR created automatically by Jules for task [4304933636949065693](https://jules.google.com/task/4304933636949065693) started by @tony84727*